### PR TITLE
release: First release 1.0.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,8 @@ jobs:
           - arch: aarch64
             runs_on: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs_on }}
+    env:
+      MMTK_GC_TRIGGER: DynamicHeapSize:1G,6G
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,13 +85,7 @@ jobs:
           
           sudo apt-get install -y clang lld rsync make
           
-
-      - name: Build runtime
-        shell: bash 
-        run: |
-          make build-runtime
-
-      - name: Bootstrap Scheme stdlib 
+      - name: Build Capy
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld rsync make fakeroot rpm
 
-      - name: Build runtime
-        shell: bash
-        run: |
-          set -euo pipefail
-          make build-runtime
-
-      - name: Bootstrap Scheme stdlib
+      - name: Build Capy
         shell: bash
         env:
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build release (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs_on: ubuntu-latest
+          - arch: aarch64
+            runs_on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs_on }}
+    env:
+      MMTK_GC_TRIGGER: DynamicHeapSize:1G,6G
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang lld rsync make fakeroot rpm
+
+      - name: Build runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          make build-runtime
+
+      - name: Bootstrap Scheme stdlib
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          make VERSION="$VERSION" build
+
+      - name: Create portable tarball
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          make VERSION="$VERSION" dist-portable
+
+      - name: Create .deb package
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION_NO_V="${VERSION#v}"
+          make VERSION="$VERSION_NO_V" dist-deb
+
+      - name: Create .rpm package
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION_NO_V="${VERSION#v}"
+          make VERSION="$VERSION_NO_V" dist-rpm
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: capyscheme-${{ github.ref_name }}-${{ matrix.arch }}
+          if-no-files-found: error
+          path: |
+            dist/*.tar.gz
+            dist/*.deb
+            dist/*.rpm
+
+  publish:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: capyscheme-${{ github.ref_name }}-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.deb
+            dist/*.rpm

--- a/capy/src/runtime/vm/load.rs
+++ b/capy/src/runtime/vm/load.rs
@@ -308,6 +308,7 @@ pub fn find_path_to<'gc>(
                 candidates.push(path);
             }
         }
+
         if filename.extension().is_some() {
             candidates.push(filename.to_owned());
         }


### PR DESCRIPTION
CapyScheme is now at the point where it's mostly stable and has easy to build process and stable CLI interface. It's safe to release 1.0.0. release (I don't want to start with 0.1.0 because it just does not look great). 